### PR TITLE
Implement transactions

### DIFF
--- a/executor/src/main/java/com/jaoow/sql/executor/CurrentThreadExecutor.java
+++ b/executor/src/main/java/com/jaoow/sql/executor/CurrentThreadExecutor.java
@@ -1,0 +1,14 @@
+package com.jaoow.sql.executor;
+
+import java.util.concurrent.Executor;
+
+/**
+ * This class is a implementation of Executor
+ * It is used to run a given command in the current thread (synchronous).
+ */
+public class CurrentThreadExecutor implements Executor {
+    @Override
+    public void execute(Runnable command) {
+        command.run();
+    }
+}

--- a/executor/src/main/java/com/jaoow/sql/executor/SQLExecutor.java
+++ b/executor/src/main/java/com/jaoow/sql/executor/SQLExecutor.java
@@ -1,5 +1,6 @@
 package com.jaoow.sql.executor;
 
+import com.jaoow.sql.connector.ConnectorException;
 import com.jaoow.sql.connector.SQLConnector;
 import com.jaoow.sql.executor.adapter.SQLResultAdapter;
 import com.jaoow.sql.executor.batch.BatchBuilder;
@@ -12,10 +13,7 @@ import org.intellij.lang.annotations.Language;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
+import java.sql.*;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -29,7 +27,8 @@ import java.util.concurrent.atomic.AtomicReference;
 @AllArgsConstructor
 public final class SQLExecutor {
 
-    private static final StatementConsumer EMPTY_STATEMENT = statement -> {};
+    private static final StatementConsumer EMPTY_STATEMENT = statement -> {
+    };
 
     @NotNull private final SQLConnector sqlConnector;
     @NotNull private final Map<Class<?>, SQLResultAdapter<?>> adapters;
@@ -49,22 +48,69 @@ public final class SQLExecutor {
     /**
      * Set the executor to perform asynchronous statements.
      *
-     * @param executor  tbe @{@link Executor}.
+     * @param executor tbe @{@link Executor}.
      */
     public void setExecutor(@NotNull Executor executor) {
         this.executor = executor;
     }
 
     /**
+     * This method is used to get the current executor.
+     * If there is no transaction associated with the current thread, it returns the default executor.
+     * If there is a transaction associated with the current thread, it returns the executor associated with that transaction.
+     * If the executor associated with the transaction is null, it throws a NullPointerException with a descriptive message.
+     *
+     * @return the current executor, either the default one or the one associated with the transaction of the current thread
+     * @throws NullPointerException if the executor associated with the transaction of the current thread is null
+     */
+    public Executor getCurrentExecutor() {
+        if (ThreadLocalTransaction.get() == null) {
+            return executor;
+        }
+
+        final Executor executor = ThreadLocalTransaction.get().getExecutor();
+
+        Objects.requireNonNull(executor, "There is a transaction to the current thread but its executor is null.");
+
+        return executor;
+    }
+
+    /**
+     * This method is used to get the current SQLConnector.
+     * If there is no transaction associated with the current thread, it returns the default SQLConnector.
+     * If there is a transaction associated with the current thread, it returns a SQLConnector that uses the connection associated with that transaction.
+     * If the connection associated with the transaction is null, it throws a NullPointerException with a descriptive message.
+     *
+     * @return the current SQLConnector, either the default one or the one associated with the connection of the current thread
+     * @throws NullPointerException if the connection associated with the transaction of the current thread is null
+     */
+    public SQLConnector getCurrentConnection() {
+        if (ThreadLocalTransaction.get() == null) {
+            return sqlConnector;
+        }
+
+        final Connection connection = ThreadLocalTransaction.get().getConnection();
+
+        Objects.requireNonNull(connection, "There is a transaction to the current thread but its connection is null.");
+
+        return consumer -> {
+            try {
+                consumer.execute(connection);
+            } catch (SQLException exception) {
+                throw new ConnectorException(exception);
+            }
+        };
+    }
+
+    /**
      * Get the registered @{@link SQLResultAdapter}.
      *
-     * @param clazz     the type of class of adapter.
-     * @param <T>       the returned type.
-     *
+     * @param clazz the type of class of adapter.
+     * @param <T>   the returned type.
      * @return the @{@link SQLResultAdapter}.
      */
     @NotNull
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings ( "unchecked" )
     public <T> SQLResultAdapter<T> getAdapter(@NotNull Class<T> clazz) {
         SQLResultAdapter<?> adapter = adapters.get(clazz);
         if (adapter == null) {
@@ -77,10 +123,9 @@ public final class SQLExecutor {
     /**
      * Register adapters to map queries.
      *
-     * @param clazz     the class of adapter.
-     * @param adapter   the @{@link SQLResultAdapter} of clazz.
-     * @param <T>       the type.
-     *
+     * @param clazz   the class of adapter.
+     * @param adapter the @{@link SQLResultAdapter} of clazz.
+     * @param <T>     the type.
      * @return the @{@link SQLExecutor}.
      */
     @NotNull
@@ -92,47 +137,44 @@ public final class SQLExecutor {
     /**
      * Execute a database statement.
      *
-     * @param sql       the sql statement.
+     * @param sql the sql statement.
      * @see #executeAsync(String) to execute statement in asynchronous thread.
      */
-    public void execute(@Language("MySQL") @NotNull String sql) {
+    public void execute(@Language ( "MySQL" ) @NotNull String sql) {
         execute(sql, EMPTY_STATEMENT);
     }
 
     /**
      * Execute a database statement.
      *
-     * @param sql       the sql statement.
-     * @param prepare   the @{@link PreparedStatement} to prepare statement.
-     *
+     * @param sql     the sql statement.
+     * @param prepare the @{@link PreparedStatement} to prepare statement.
      * @see #executeAsync(String, StatementConsumer) to execute statement in asynchronous thread.
      */
-    public void execute(@Language("MySQL") @NotNull String sql, @NotNull StatementConsumer prepare) {
+    public void execute(@Language ( "MySQL" ) @NotNull String sql, @NotNull StatementConsumer prepare) {
         execute(sql, Statement.NO_GENERATED_KEYS, prepare, EMPTY_STATEMENT);
     }
 
     /**
      * Execute a database statement and retrieve its result.
      *
-     * @param sql       The sql statement.
-     * @param result    The @{@link ResultSetConsumer} to accept result.
-     *
+     * @param sql    The sql statement.
+     * @param result The @{@link ResultSetConsumer} to accept result.
      * @see #executeAsync(String, ResultSetConsumer) to execute statement in asynchronous thread.
      */
-    public void execute(@Language("MySQL") @NotNull String sql, @NotNull ResultSetConsumer result) {
+    public void execute(@Language ( "MySQL" ) @NotNull String sql, @NotNull ResultSetConsumer result) {
         execute(sql, EMPTY_STATEMENT, result);
     }
 
     /**
      * Execute a database statement and retrieve its result.
      *
-     * @param sql       The sql statement.
-     * @param prepare   The @{@link PreparedStatement} to prepare statement.
-     * @param result    The @{@link ResultSetConsumer} to accept result.
-     *
+     * @param sql     The sql statement.
+     * @param prepare The @{@link PreparedStatement} to prepare statement.
+     * @param result  The @{@link ResultSetConsumer} to accept result.
      * @see #executeAsync(String, StatementConsumer, ResultSetConsumer) to execute statement in asynchronous thread.
      */
-    public void execute(@Language("MySQL") @NotNull String sql, @NotNull StatementConsumer prepare, @NotNull ResultSetConsumer result) {
+    public void execute(@Language ( "MySQL" ) @NotNull String sql, @NotNull StatementConsumer prepare, @NotNull ResultSetConsumer result) {
         execute(sql, Statement.RETURN_GENERATED_KEYS, prepare, statement -> {
             try (ResultSet set = statement.getGeneratedKeys()) {
                 result.accept(set);
@@ -143,18 +185,16 @@ public final class SQLExecutor {
     /**
      * Execute a database statement and retrieve its after execution.
      *
-     * @param sql                   The sql statement.
-     * @param autoGeneratedKeys     The flag to indicate if auto generated keys should be retrieved.
-     * @param prepare               The @{@link PreparedStatement} to prepare statement.
-     * @param result                The @{@link ResultSetConsumer} to accept result.
-     *
+     * @param sql               The sql statement.
+     * @param autoGeneratedKeys The flag to indicate if auto generated keys should be retrieved.
+     * @param prepare           The @{@link PreparedStatement} to prepare statement.
+     * @param result            The @{@link ResultSetConsumer} to accept result.
      * @see #executeAsync(String, int, StatementConsumer, StatementConsumer) to execute statement in asynchronous thread.
      */
-    public void execute(@Language("MySQL") @NotNull String sql, int autoGeneratedKeys,
+    public void execute(@Language ( "MySQL" ) @NotNull String sql, int autoGeneratedKeys,
                         @NotNull StatementConsumer prepare,
                         @NotNull StatementConsumer result) {
-
-        sqlConnector.execute(connection -> {
+        getCurrentConnection().execute(connection -> {
             try (PreparedStatement statement = connection.prepareStatement(sql, autoGeneratedKeys)) {
                 prepare.accept(statement);
                 statement.execute();
@@ -166,14 +206,13 @@ public final class SQLExecutor {
     /**
      * Execute a database statement in asynchronous thread.
      *
-     * @param sql   the sql statement.
-     *
+     * @param sql the sql statement.
      * @return the completable future.
      * @see #execute(String) to execute statment in synchronously.
      */
-    @Contract("_ -> new")
-    public @NotNull CompletableFuture<Void> executeAsync(@Language("MySQL") @NotNull String sql) {
-        return CompletableFuture.runAsync(() -> execute(sql), executor);
+    @Contract ( "_ -> new" )
+    public @NotNull CompletableFuture<Void> executeAsync(@Language ( "MySQL" ) @NotNull String sql) {
+        return CompletableFuture.runAsync(() -> execute(sql), getCurrentExecutor());
     }
 
     /**
@@ -181,62 +220,58 @@ public final class SQLExecutor {
      *
      * @param sql      the sql statement.
      * @param consumer the @{@link PreparedStatement} to prepare statement.
-     *
      * @return the completable future of execution.
      * @see #execute(String, StatementConsumer) to execute statement in synchronously.
      */
-    @Contract("_, _ -> new")
-    public @NotNull CompletableFuture<Void> executeAsync(@Language("MySQL") @NotNull String sql, @NotNull StatementConsumer consumer) {
-        return CompletableFuture.runAsync(() -> execute(sql, consumer), executor);
+    @Contract ( "_, _ -> new" )
+    public @NotNull CompletableFuture<Void> executeAsync(@Language ( "MySQL" ) @NotNull String sql, @NotNull StatementConsumer consumer) {
+        return CompletableFuture.runAsync(() -> execute(sql, consumer), getCurrentExecutor());
     }
 
     /**
      * Execute a database statement and retrieve its result in an asynchronous thread.
      *
-     * @param sql       The sql statement.
-     * @param result    The @{@link ResultSetConsumer} to accept result.
-     *
+     * @param sql    The sql statement.
+     * @param result The @{@link ResultSetConsumer} to accept result.
      * @return the completable future of execution.
      * @see #execute(String, ResultSetConsumer) to execute statement in synchronously.
      */
-    public @NotNull CompletableFuture<Void> executeAsync(@Language("MySQL") @NotNull String sql, @NotNull ResultSetConsumer result) {
-        return CompletableFuture.runAsync(() -> execute(sql, result), executor);
+    public @NotNull CompletableFuture<Void> executeAsync(@Language ( "MySQL" ) @NotNull String sql, @NotNull ResultSetConsumer result) {
+        return CompletableFuture.runAsync(() -> execute(sql, result), getCurrentExecutor());
     }
 
     /**
      * Execute a database statement and retrieve its result in an asynchronous thread.
      *
-     * @param sql       The sql statement.
-     * @param prepare   The @{@link PreparedStatement} to prepare statement.
-     * @param result    The @{@link ResultSetConsumer} to accept result.
-     *
+     * @param sql     The sql statement.
+     * @param prepare The @{@link PreparedStatement} to prepare statement.
+     * @param result  The @{@link ResultSetConsumer} to accept result.
      * @return the completable future of execution.
      * @see #execute(String, StatementConsumer, ResultSetConsumer) to execute statement in synchronously.
      */
-    public @NotNull CompletableFuture<Void> executeAsync(@Language("MySQL") @NotNull String sql,
+    public @NotNull CompletableFuture<Void> executeAsync(@Language ( "MySQL" ) @NotNull String sql,
                                                          @NotNull StatementConsumer prepare,
                                                          @NotNull ResultSetConsumer result) {
 
-        return CompletableFuture.runAsync(() -> execute(sql, prepare, result), executor);
+        return CompletableFuture.runAsync(() -> execute(sql, prepare, result), getCurrentExecutor());
     }
 
     /**
      * Execute a database statement and retrieve after its execution in an asynchronous thread.
      *
-     * @param sql                   The sql statement.
-     * @param autoGeneratedKeys     The flag to indicate if auto generated keys should be retrieved.
-     * @param prepare               The @{@link PreparedStatement} to prepare statement.
-     * @param result                The @{@link ResultSetConsumer} to accept result.
-     *
+     * @param sql               The sql statement.
+     * @param autoGeneratedKeys The flag to indicate if auto generated keys should be retrieved.
+     * @param prepare           The @{@link PreparedStatement} to prepare statement.
+     * @param result            The @{@link ResultSetConsumer} to accept result.
      * @return the completable future of execution
      * @see #execute(String, int, StatementConsumer, StatementConsumer) to execute statement in synchronously.
      */
-    public @NotNull CompletableFuture<Void> executeAsync(@Language("MySQL") @NotNull String sql,
+    public @NotNull CompletableFuture<Void> executeAsync(@Language ( "MySQL" ) @NotNull String sql,
                                                          int autoGeneratedKeys,
                                                          @NotNull StatementConsumer prepare,
                                                          @NotNull StatementConsumer result) {
 
-        return CompletableFuture.runAsync(() -> execute(sql, autoGeneratedKeys, prepare, result), executor);
+        return CompletableFuture.runAsync(() -> execute(sql, autoGeneratedKeys, prepare, result), getCurrentExecutor());
     }
 
     /**
@@ -247,15 +282,14 @@ public final class SQLExecutor {
      * @param function the function to map @{@link ResultSet}
      * @param <T>      the returned type
      * @return the optional result of query
-     *
      * @see #queryAsync(String, StatementConsumer, ResultSetFunction) to query in asynchronous.
      */
-    public <T> Optional<T> query(@Language("MySQL") @NotNull String query,
+    public <T> Optional<T> query(@Language ( "MySQL" ) @NotNull String query,
                                  @NotNull StatementConsumer consumer,
                                  @NotNull ResultSetFunction<T> function) {
 
         AtomicReference<Optional<T>> reference = new AtomicReference<>(Optional.empty());
-        sqlConnector.execute(connection -> {
+        getCurrentConnection().execute(connection -> {
             try (PreparedStatement statement = connection.prepareStatement(query)) {
                 consumer.accept(statement);
                 try (ResultSet resultSet = statement.executeQuery()) {
@@ -274,10 +308,9 @@ public final class SQLExecutor {
      * @param function the function to map @{@link ResultSet}
      * @param <T>      the returned type
      * @return the optional result of query
-     *
      * @see #queryAsync(String, ResultSetFunction) to execute in asynchronous thread.
      */
-    public <T> Optional<T> query(@Language("MySQL") @NotNull String query, @NotNull ResultSetFunction<T> function) {
+    public <T> Optional<T> query(@Language ( "MySQL" ) @NotNull String query, @NotNull ResultSetFunction<T> function) {
         return query(query, EMPTY_STATEMENT, function);
     }
 
@@ -290,7 +323,7 @@ public final class SQLExecutor {
      * @return the entity founded, or null
      * @see #queryAsync(String, Class) to execute in asynchronous thread
      */
-    public <T> Optional<T> query(@Language("MySQL") @NotNull String query, @NotNull Class<T> clazz) {
+    public <T> Optional<T> query(@Language ( "MySQL" ) @NotNull String query, @NotNull Class<T> clazz) {
         return query(query, EMPTY_STATEMENT, resultSet -> resultSet.next() ? getAdapter(clazz).adaptResult(resultSet) : null);
     }
 
@@ -302,10 +335,9 @@ public final class SQLExecutor {
      * @param consumer The statement consumer
      * @param clazz    The class to search adapter
      * @return The entity founded, or null
-     *
      * @see #queryAsync(String, StatementConsumer, Class) to execute in asynchronous thread
      */
-    public <T> Optional<T> query(@Language("MySQL") @NotNull String query,
+    public <T> Optional<T> query(@Language ( "MySQL" ) @NotNull String query,
                                  @NotNull StatementConsumer consumer,
                                  @NotNull Class<T> clazz
     ) {
@@ -317,10 +349,9 @@ public final class SQLExecutor {
      *
      * @param query the sql query
      * @return the optional result of query
-     *
      * @see #queryAsync(String) to execute in asynchronous thread.
      */
-    public Optional<ResultSet> query(@Language("MySQL") @NotNull String query) {
+    public Optional<ResultSet> query(@Language ( "MySQL" ) @NotNull String query) {
         return query(query, EMPTY_STATEMENT);
     }
 
@@ -330,12 +361,11 @@ public final class SQLExecutor {
      * @param query    the query to select the entity.
      * @param consumer The statement consumer
      * @return the entity founded, or null
-     *
      * @see #queryAsync(String, StatementConsumer) to execute in asynchronous thread
      */
-    public Optional<ResultSet> query(@Language("MySQL") @NotNull String query, @NotNull StatementConsumer consumer) {
+    public Optional<ResultSet> query(@Language ( "MySQL" ) @NotNull String query, @NotNull StatementConsumer consumer) {
         AtomicReference<Optional<ResultSet>> reference = new AtomicReference<>(Optional.empty());
-        sqlConnector.execute(connection -> {
+        getCurrentConnection().execute(connection -> {
             try (PreparedStatement statement = connection.prepareStatement(query)) {
                 consumer.accept(statement);
                 reference.set(Optional.ofNullable(statement.executeQuery()));
@@ -352,15 +382,14 @@ public final class SQLExecutor {
      * @param function the function to map @{@link ResultSet}
      * @param <T>      the returned type
      * @return the completable future of optional query result
-     *
      * @see #query(String, StatementConsumer, ResultSetFunction)  to execute in synchronously
      */
-    @Contract("_, _, _ -> new")
-    public <T> @NotNull CompletableFuture<Optional<T>> queryAsync(@Language("MySQL") @NotNull String query,
+    @Contract ( "_, _, _ -> new" )
+    public <T> @NotNull CompletableFuture<Optional<T>> queryAsync(@Language ( "MySQL" ) @NotNull String query,
                                                                   @NotNull StatementConsumer consumer,
                                                                   @NotNull ResultSetFunction<T> function
     ) {
-        return CompletableFuture.supplyAsync(() -> query(query, consumer, function), executor);
+        return CompletableFuture.supplyAsync(() -> query(query, consumer, function), getCurrentExecutor());
     }
 
     /**
@@ -370,14 +399,13 @@ public final class SQLExecutor {
      * @param function the function to map @{@link ResultSet}
      * @param <T>      the returned type
      * @return the completable future of optional query result
-     *
      * @see #query(String, ResultSetFunction) to execute in synchronously
      */
-    @Contract("_, _ -> new")
-    public <T> @NotNull CompletableFuture<Optional<T>> queryAsync(@Language("MySQL") @NotNull String query,
+    @Contract ( "_, _ -> new" )
+    public <T> @NotNull CompletableFuture<Optional<T>> queryAsync(@Language ( "MySQL" ) @NotNull String query,
                                                                   @NotNull ResultSetFunction<T> function
     ) {
-        return CompletableFuture.supplyAsync(() -> query(query, function), executor);
+        return CompletableFuture.supplyAsync(() -> query(query, function), getCurrentExecutor());
     }
 
     /**
@@ -390,12 +418,12 @@ public final class SQLExecutor {
      * @return the completable future of optional query result
      * @see #query(String, StatementConsumer, Class) to execute in synchronously
      */
-    @Contract("_, _, _ -> new")
-    public <T> @NotNull CompletableFuture<Optional<T>> queryAsync(@Language("MySQL") @NotNull String query,
+    @Contract ( "_, _, _ -> new" )
+    public <T> @NotNull CompletableFuture<Optional<T>> queryAsync(@Language ( "MySQL" ) @NotNull String query,
                                                                   @NotNull StatementConsumer consumer,
                                                                   @NotNull Class<T> clazz
     ) {
-        return CompletableFuture.supplyAsync(() -> query(query, consumer, clazz), executor);
+        return CompletableFuture.supplyAsync(() -> query(query, consumer, clazz), getCurrentExecutor());
     }
 
 
@@ -406,12 +434,11 @@ public final class SQLExecutor {
      * @param clazz the class to search adapter
      * @param <T>   the returned type
      * @return the completable future of optional query result
-     *
      * @see #query(String, Class) to execute in synchronously
      */
-    @Contract("_, _ -> new")
-    public <T> @NotNull CompletableFuture<Optional<T>> queryAsync(@Language("MySQL") @NotNull String query, @NotNull Class<T> clazz) {
-        return CompletableFuture.supplyAsync(() -> query(query, clazz), executor);
+    @Contract ( "_, _ -> new" )
+    public <T> @NotNull CompletableFuture<Optional<T>> queryAsync(@Language ( "MySQL" ) @NotNull String query, @NotNull Class<T> clazz) {
+        return CompletableFuture.supplyAsync(() -> query(query, clazz), getCurrentExecutor());
     }
 
     /**
@@ -419,12 +446,11 @@ public final class SQLExecutor {
      *
      * @param query the sql query
      * @return the completable future of optional query result
-     *
      * @see #query(String, Class) to execute in synchronously
      */
-    @Contract("_ -> new")
-    public @NotNull CompletableFuture<Optional<ResultSet>> queryAsync(@Language("MySQL") @NotNull String query) {
-        return CompletableFuture.supplyAsync(() -> query(query), executor);
+    @Contract ( "_ -> new" )
+    public @NotNull CompletableFuture<Optional<ResultSet>> queryAsync(@Language ( "MySQL" ) @NotNull String query) {
+        return CompletableFuture.supplyAsync(() -> query(query), getCurrentExecutor());
     }
 
     /**
@@ -433,14 +459,13 @@ public final class SQLExecutor {
      * @param query    the sql query
      * @param consumer the @{@link ResultSet} to prepare query
      * @return the completable future of optional query result
-     *
      * @see #query(String, StatementConsumer) to execute in synchronously
      */
-    @Contract("_, _ -> new")
-    public @NotNull CompletableFuture<Optional<ResultSet>> queryAsync(@Language("MySQL") @NotNull String query,
+    @Contract ( "_, _ -> new" )
+    public @NotNull CompletableFuture<Optional<ResultSet>> queryAsync(@Language ( "MySQL" ) @NotNull String query,
                                                                       @NotNull StatementConsumer consumer
     ) {
-        return CompletableFuture.supplyAsync(() -> query(query, consumer), executor);
+        return CompletableFuture.supplyAsync(() -> query(query, consumer), getCurrentExecutor());
     }
 
     /**
@@ -451,15 +476,14 @@ public final class SQLExecutor {
      * @param clazz    the class to search @{@link SQLResultAdapter}
      * @param <T>      the returned type
      * @return the completable future of @{@link Set} of result
-     *
      * @see #queryMany(String, StatementConsumer, Class) to execute in synchronously.
      */
-    @Contract("_, _, _ -> new")
-    public <T> @NotNull CompletableFuture<Set<T>> queryManyAsync(@Language("MySQL") @NotNull String query,
+    @Contract ( "_, _, _ -> new" )
+    public <T> @NotNull CompletableFuture<Set<T>> queryManyAsync(@Language ( "MySQL" ) @NotNull String query,
                                                                  @NotNull StatementConsumer consumer,
                                                                  @NotNull Class<T> clazz) {
 
-        return CompletableFuture.supplyAsync(() -> queryMany(query, consumer, clazz), executor);
+        return CompletableFuture.supplyAsync(() -> queryMany(query, consumer, clazz), getCurrentExecutor());
     }
 
     /**
@@ -470,10 +494,9 @@ public final class SQLExecutor {
      * @param consumer the statement consumer
      * @param clazz    the class to search @{@link SQLResultAdapter}
      * @return The entities found
-     *
      * @see #queryManyAsync(String, StatementConsumer, Class)  to execute in asynchronous thread
      */
-    public <T> Set<T> queryMany(@Language("MySQL") @NotNull String query,
+    public <T> Set<T> queryMany(@Language ( "MySQL" ) @NotNull String query,
                                 @NotNull StatementConsumer consumer,
                                 @NotNull Class<T> clazz
     ) {
@@ -499,12 +522,11 @@ public final class SQLExecutor {
      * @param clazz the class to search @{@link SQLResultAdapter}
      * @param <T>   the returned type
      * @return the completable future of @{@link Set} of result
-     *
      * @see #queryMany(String, Class) to execute in synchronously
      */
-    @Contract("_, _ -> new")
-    public <T> @NotNull CompletableFuture<Set<T>> queryManyAsync(@Language("MySQL") @NotNull String query, @NotNull Class<T> clazz) {
-        return CompletableFuture.supplyAsync(() -> queryMany(query, clazz), executor);
+    @Contract ( "_, _ -> new" )
+    public <T> @NotNull CompletableFuture<Set<T>> queryManyAsync(@Language ( "MySQL" ) @NotNull String query, @NotNull Class<T> clazz) {
+        return CompletableFuture.supplyAsync(() -> queryMany(query, clazz), getCurrentExecutor());
     }
 
     /**
@@ -514,10 +536,9 @@ public final class SQLExecutor {
      * @param query the query to select entities
      * @param clazz the class to search @{@link SQLResultAdapter}
      * @return The entities found
-     *
      * @see #queryManyAsync(String, Class) to execute in asynchronous thread
      */
-    public <T> Set<T> queryMany(@Language("MySQL") @NotNull String query, @NotNull Class<T> clazz) {
+    public <T> Set<T> queryMany(@Language ( "MySQL" ) @NotNull String query, @NotNull Class<T> clazz) {
         return queryMany(query, EMPTY_STATEMENT, clazz);
     }
 
@@ -528,8 +549,8 @@ public final class SQLExecutor {
      * @param statement the statement to prepare for batching.
      * @return a BatchBuilder
      */
-    @Contract("_ -> new")
-    public @NotNull BatchBuilder batch(@Language("MySQL") @NotNull String statement) {
+    @Contract ( "_ -> new" )
+    public @NotNull BatchBuilder batch(@Language ( "MySQL" ) @NotNull String statement) {
         return new BatchBuilder(statement, this);
     }
 
@@ -544,7 +565,6 @@ public final class SQLExecutor {
      * handler can safely be referred to {@link #execute(String, StatementConsumer)}</p>
      *
      * @param builder the builder to be used.
-     *
      * @see #executeBatchAsync(BatchBuilder) to perform this action asynchronously.
      */
     public void executeBatch(@NotNull BatchBuilder builder) {
@@ -561,9 +581,8 @@ public final class SQLExecutor {
      * batched statement. For instance, a BatchBuilder with only one
      * handler can safely be referred to {@link #execute(String, StatementConsumer)}</p>
      *
-     * @param builder   The builder to be used.
-     * @param result    The result to be accepted.
-     *
+     * @param builder The builder to be used.
+     * @param result  The result to be accepted.
      * @see #executeBatchAsync(BatchBuilder, ResultSetConsumer) to perform this action asynchronously.
      */
     public void executeBatch(@NotNull BatchBuilder builder, ResultSetConsumer result) {
@@ -584,10 +603,9 @@ public final class SQLExecutor {
      * batched statement. For instance, a BatchBuilder with only one
      * handler can safely be referred to {@link #execute(String, StatementConsumer)}</p>
      *
-     * @param builder               The builder to be used.
-     * @param autoGeneratedKeys     The flag to indicate if auto generated keys should be retrieved.
-     * @param result                The result to be accepted.
-     *
+     * @param builder           The builder to be used.
+     * @param autoGeneratedKeys The flag to indicate if auto generated keys should be retrieved.
+     * @param result            The result to be accepted.
      * @see #executeBatchAsync(BatchBuilder, int, StatementConsumer) to perform this action asynchronously.
      */
     public void executeBatch(@NotNull BatchBuilder builder, int autoGeneratedKeys, @NotNull StatementConsumer result) {
@@ -597,7 +615,7 @@ public final class SQLExecutor {
             return;
         }
 
-        sqlConnector.execute(connection -> {
+        getCurrentConnection().execute(connection -> {
             try (PreparedStatement statement = connection.prepareStatement(builder.getStatement(), autoGeneratedKeys)) {
                 for (StatementConsumer handlers : builder.getHandlers()) {
                     handlers.accept(statement);
@@ -622,10 +640,9 @@ public final class SQLExecutor {
      *
      * @param builder the builder to be used.
      * @return a Promise of an asynchronous batched database execution
-     *
      * @see #executeBatch(BatchBuilder) to perform this action synchronously
      */
-    @Contract("_ -> new")
+    @Contract ( "_ -> new" )
     public @NotNull CompletableFuture<Void> executeBatchAsync(@NotNull BatchBuilder builder) {
         return CompletableFuture.runAsync(() -> this.executeBatch(builder));
     }
@@ -640,13 +657,12 @@ public final class SQLExecutor {
      * batched statement. For instance, a BatchBuilder with only one
      * handler can safely be referred to {@link #executeAsync(String, StatementConsumer, ResultSetConsumer)}</p>
      *
-     * @param builder   The builder to be used.
-     * @param result    The result to be accepted.
-     *
+     * @param builder The builder to be used.
+     * @param result  The result to be accepted.
      * @return a Promise of an asynchronous batched database execution
      * @see #executeBatch(BatchBuilder, ResultSetConsumer) to perform this action synchronously
      */
-    @Contract("_,_ -> new")
+    @Contract ( "_,_ -> new" )
     public @NotNull CompletableFuture<Void> executeBatchAsync(@NotNull BatchBuilder builder, @NotNull ResultSetConsumer result) {
         return CompletableFuture.runAsync(() -> this.executeBatch(builder, result));
     }
@@ -661,16 +677,44 @@ public final class SQLExecutor {
      * batched statement. For instance, a BatchBuilder with only one
      * handler can safely be referred to {@link #executeAsync(String, int, StatementConsumer, StatementConsumer)}</p>
      *
-     * @param builder               The builder to be used.
-     * @param autoGeneratedKeys     The flag to indicate if auto generated keys should be retrieved.
-     * @param result                The result to be accepted.
-     *
+     * @param builder           The builder to be used.
+     * @param autoGeneratedKeys The flag to indicate if auto generated keys should be retrieved.
+     * @param result            The result to be accepted.
      * @return a Promise of an asynchronous batched database execution
      * @see #executeBatch(BatchBuilder, int, StatementConsumer) to perform this action synchronously
      */
-    @Contract("_,_,_ -> new")
+    @Contract ( "_,_,_ -> new" )
     public @NotNull CompletableFuture<Void> executeBatchAsync(@NotNull BatchBuilder builder, int autoGeneratedKeys, @NotNull StatementConsumer result) {
         return CompletableFuture.runAsync(() -> this.executeBatch(builder, autoGeneratedKeys, result));
+    }
+
+    /**
+     * Any query to the database using any method from SQLExecutor (like execute, executeAsync, query, queryAsync, etc..) will be executed inside a transaction (will reuse the same connection).
+     * If any exception is thrown during the execution of the runnable, it rolls back the transaction and rethrows the exception as a RuntimeException.
+     * All code inside runnable  will be executed asynchronously using the default executor.
+     *
+     * @param runnable the Runnable to be executed within the transaction
+     * @return a CompletableFuture that will be completed when the transaction and the execution of the runnable are finished
+     */
+    public CompletableFuture<Void> withTransaction(Runnable runnable) {
+        return CompletableFuture.runAsync(() -> {
+            sqlConnector.execute(connection -> {
+                connection.setAutoCommit(false);
+
+                final SQLTransactionHolder transactionHolder = new SQLTransactionHolder(connection, new CurrentThreadExecutor());
+                ThreadLocalTransaction.set(transactionHolder);
+
+                try {
+                    runnable.run();
+                    connection.commit();
+                } catch (Throwable t) {
+                    connection.rollback();
+                    throw new RuntimeException(t);
+                } finally {
+                    ThreadLocalTransaction.remove();
+                }
+            });
+        }, executor);
     }
 
 }

--- a/executor/src/main/java/com/jaoow/sql/executor/SQLTransactionHolder.java
+++ b/executor/src/main/java/com/jaoow/sql/executor/SQLTransactionHolder.java
@@ -1,0 +1,12 @@
+package com.jaoow.sql.executor;
+
+import lombok.Data;
+
+import java.sql.Connection;
+import java.util.concurrent.Executor;
+
+@Data
+public class SQLTransactionHolder {
+    private final Connection connection;
+    private final Executor executor;
+}

--- a/executor/src/main/java/com/jaoow/sql/executor/ThreadLocalTransaction.java
+++ b/executor/src/main/java/com/jaoow/sql/executor/ThreadLocalTransaction.java
@@ -1,0 +1,34 @@
+package com.jaoow.sql.executor;
+
+public class ThreadLocalTransaction {
+    private static final ThreadLocal<SQLTransactionHolder> THREAD_LOCAL_TRANSACTION = new ThreadLocal<>();
+
+
+    /**
+     * This method is used to get the SQLTransactionHolder associated with the current thread.
+     * If there is no SQLTransactionHolder associated with the current thread, it returns null.
+     *
+     * @return the SQLTransactionHolder associated with the current thread, or null if there is none
+     */
+    public static SQLTransactionHolder get() {
+        return THREAD_LOCAL_TRANSACTION.get();
+    }
+
+    /**
+     * This method is used to set the SQLTransactionHolder associated with the current thread.
+     * If there is already a SQLTransactionHolder associated with the current thread, it is replaced.
+     *
+     * @param transactionHolder the SQLTransactionHolder to be associated with the current thread
+     */
+    public static void set(SQLTransactionHolder transactionHolder) {
+        THREAD_LOCAL_TRANSACTION.set(transactionHolder);
+    }
+
+    /**
+     * This method is used to remove the SQLTransactionHolder associated with the current thread.
+     * If there is no SQLTransactionHolder associated with the current thread, this method does nothing.
+     */
+    public static void remove() {
+        THREAD_LOCAL_TRANSACTION.remove();
+    }
+}


### PR DESCRIPTION
Implemented transactions, there is a function `SQLExecutor#withTransaction(Callable callable)`, if any SQLExecutor function is executed inside this callable (such as execute, executeAsync, query, queryAsync, etc...) all them will reuse the same connection, if any exception is thrown, the connection is rollbacked, otherwise commited.

The `withTransaction` is executed in a CompletableFuture using the default executor, and the Connection object is shared between all database calls using `ThreadLocalTransaction` which holds `SQLTransactionHolder` objects for a specific thread (the thread that `withTransaction` creates using the executor).

In order to the `SQLTransactionHolder` be available to all async calls, all calls to async functions such as queryAsync, executeAsync, inside the callable, will be executed synchronously using the `CurrentThreadExecutor` executor, in the same thread that `withTransaction` creates.

Examples:

```java
// BankService.java

private final SQLExecutor sqlExexcutor = ...;
private final TransactionRepository transactionRepository;
private final UserRepository userRepository;

public CompletableFuture<Void> giveCoins(String username, double amount) {
    return sqlExexcutor.withTransaction(() -> {
        final User user = userRepository.getByName(username);
        user.increaseCoins(amount);

        // operation 1
        userRepository.save(user).join();

        // operation 2
        transactionRepository.save(
            new Transaction(user.getName(), amount, LocalDateTime.now())
        ).join();
        // the operation 1 will use the same connection as the operation 2, and both operations need to be executed without thrown exceptions, otherwise they will be rollbacked
    });
}

```